### PR TITLE
Only skip static cache if user has CP access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes for Servd Assets and Helpers
 
+## 2.5.0 - 2021-12-16
+
+### Changed
+
+- The option to skip the cache for logged in users has been restricted to users with control panel access - so front-end-only users don't have all static caching disabled when they log in.
+
 ## 2.4.11 - 2021-12-15
 
 ### Updated

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "servd/craft-asset-storage",
     "description": "Servd Asset Storage and Helpers integration for Craft CMS",
-    "version": "2.4.11",
+    "version": "2.5.0",
     "type": "craft-plugin",
     "keywords": [
         "cms",

--- a/src/StaticCache/StaticCache.php
+++ b/src/StaticCache/StaticCache.php
@@ -272,7 +272,7 @@ class StaticCache extends Component
     private function registerLoggedInHandlers()
     {
         Event::on(Application::class, Application::EVENT_INIT, function () {
-            if (Craft::$app->getUser()->isGuest) {
+            if (!Craft::$app->getUser()->checkPermission('accessCp')) {
                 Craft::$app->response->cookies->remove('SERVD_LOGGED_IN_STATUS');
             } else {
                 $domain = Craft::$app->getConfig()->getGeneral()->defaultCookieDomain;


### PR DESCRIPTION
This is potentially a breaking change if a project relies on non-cp logged in users skipping the cache. I'm not aware of any such projects currently in prod.

The benefit of the change is that it allows control panel users to skip the cache and see admin-only content displayed, which not completely disabling the cache for logged in users on membership sites.