### PR TITLE
Feature/respect upscaleimages config

### DIFF
--- a/src/AssetsPlatform/ImageTransforms.php
+++ b/src/AssetsPlatform/ImageTransforms.php
@@ -127,54 +127,54 @@ class ImageTransforms
         $autoParams = [];
 
         if (!empty($transform->quality)) {
-          $params['q'] = $transform->quality;
+            $params['q'] = $transform->quality;
         } else {
-          $default = Craft::$app->getConfig()->getGeneral()->defaultImageQuality;
-          if (empty($default) || $default == 82) { // 82 is the Craft default
-            $autoParams[] = 'compress';
-          } else {
-            $params['q'] = $default;
-          }
+            $default = Craft::$app->getConfig()->getGeneral()->defaultImageQuality;
+            if (empty($default) || $default == 82) { // 82 is the Craft default
+                $autoParams[] = 'compress';
+            } else {
+                $params['q'] = $default;
+            }
         }
-    
+
         if (!empty($transform->format)) {
-          $params['fm'] = $transform->format;
+            $params['fm'] = $transform->format;
         } elseif ($settings->imageAutoConversion == 'webp') {
-          $autoParams[] = 'format';
+            $autoParams[] = 'format';
         } elseif ($settings->imageAutoConversion == 'avif') {
-          $autoParams[] = 'format';
-          $autoParams[] = 'avif';
+            $autoParams[] = 'format';
+            $autoParams[] = 'avif';
         }
-    
+
         if (!empty($autoParams)) {
-          $params['auto'] = implode(',', $autoParams);
+            $params['auto'] = implode(',', $autoParams);
         }
-    
+
         if (!empty($transform->fit) && in_array($transform->fit, ['fillmax', 'fill', 'scale', 'crop', 'clip', 'min', 'max'])) {
-          $params['fit'] = $transform->fit;
+            $params['fit'] = $transform->fit;
         } else {
-          $params['fit'] = 'clip';
+            $params['fit'] = 'clip';
         }
-    
+
         $params['crop'] = $transform->crop;
         if ($transform->crop == 'focalpoint') {
-          if (!empty($transform->fpx) && is_numeric($transform->fpx)) {
-            $params['fp-x'] = $transform->fpx;
-          }
-    
-          if (!empty($transform->fpy) && is_numeric($transform->fpy)) {
-            $params['fp-y'] = $transform->fpy;
-          }
+            if (!empty($transform->fpx) && is_numeric($transform->fpx)) {
+                $params['fp-x'] = $transform->fpx;
+            }
+
+            if (!empty($transform->fpy) && is_numeric($transform->fpy)) {
+                $params['fp-y'] = $transform->fpy;
+            }
         }
-    
+
         if (!empty($transform->fillColor)) {
-          $params['fill-color'] = $transform->fillColor;
+            $params['fill-color'] = $transform->fillColor;
         }
-    
+
         if (!empty($transform->dpr) && is_numeric($transform->dpr) && $transform->dpr != 1) {
-          $params['dpr'] = $transform->dpr;
+            $params['dpr'] = $transform->dpr;
         }
-    
+
         return $params;
       }
     
@@ -182,31 +182,31 @@ class ImageTransforms
       {
         $upscaleImages = Craft::$app->getConfig()->getGeneral()->upscaleImages;
         $params = [];
-    
+
         if (!empty($transform->width)) {
-          $params['w'] = $upscaleImages ? $transform->width : min($transform->width, $asset->width);
+            $params['w'] = $upscaleImages ? $transform->width : min($transform->width, $asset->width);
         }
-    
+
         if (!empty($transform->height)) {
-          $params['h'] = $upscaleImages ? $transform->height : min($transform->height, $asset->height);
+            $params['h'] = $upscaleImages ? $transform->height : min($transform->height, $asset->height);
         }
-    
+
         // check that the aspect ratio has been kept if upscaleImages was set to false
         if (!empty($transform->width) && !empty($transform->height) && !$upscaleImages && ($transform->width > $asset->width || $transform->height > $asset->height)) {
-          $originalAspectRatio = $asset->width / $asset->height;
-          $targetAspectRatio = $transform->width / $transform->height;
-          if ($targetAspectRatio == 1) {
-            $params['w'] = min($transform->width, $asset->width, $asset->height);
-            $params['h'] = $params['w'];
-          } else if ($originalAspectRatio > $targetAspectRatio) {
-            $params['h'] = min($asset->height, $transform->height);
-            $params['w'] = round($params['h'] * $targetAspectRatio);
-          } else {
-            $params['w'] = min($asset->width, $transform->width);
-            $params['h'] = round($params['w'] / $targetAspectRatio);
-          }
+            $originalAspectRatio = $asset->width / $asset->height;
+            $targetAspectRatio = $transform->width / $transform->height;
+            if ($targetAspectRatio == 1) {
+                $params['w'] = min($transform->width, $asset->width, $asset->height);
+                $params['h'] = $params['w'];
+            } else if ($originalAspectRatio > $targetAspectRatio) {
+                $params['h'] = min($asset->height, $transform->height);
+                $params['w'] = round($params['h'] * $targetAspectRatio);
+            } else {
+                $params['w'] = min($asset->width, $transform->width);
+                $params['h'] = round($params['w'] / $targetAspectRatio);
+            }
         }
-    
+
         return $params;
       }
     


### PR DESCRIPTION
This code patches the `ImageTransforms` class to respect the `upscaleImages` configuration when passing parameters to the CDN for on-the-fly transforms.

It ensures that, when both width and height are provided, the desired aspect ratio is mantained, constraining the transform dimensions within the maximum size of the original image.

You might want to review the code style (I am not a versed PHP developer). I tested this in a few use cases and it works as expected.

note/edit: 

1. the `dpr` parameter does not seem to be supported by the transform service API (assuming it is bunny-cdn), but if it is, it needs to be checked against in the function that calculates the maximum image size.
2. this patch does not apply to Imager/ImageOptimize integrations

closes #73 